### PR TITLE
Fixing the dupes and the issues closed long time ago

### DIFF
--- a/lib/gh.py
+++ b/lib/gh.py
@@ -41,6 +41,9 @@ def filter_issues(issues):
             filtered_list.append(issue)
         if '[zube]: QA Working' in [x.name for x in issue.labels]:
             filtered_list.append(issue)
+        if issue.repository.name == 'dashboard':
+            if '[zube]: To Test' in [x.name for x in issue.labels]:
+                filtered_list.append(issue)
     return filtered_list
 
 
@@ -52,6 +55,13 @@ def create_date_for_spreadsheet(issues, users):
                 size_label = []
                 if len(issue.labels) > 0:
                     size_label = [label.name for label in issue.labels if label.name in size_labels.keys()]
+                dupes = [wd[2] for wd in worksheet_data if f'{issue.number} {issue.title}' in wd[2]]
+                if len(dupes) > 0:
+                    continue
+                if issue.state == 'closed':
+                    diff = get_start_date() - issue.closed_at
+                    if diff and diff.days > 0:
+                        continue
                 worksheet_data.append([
                     user.name,
                     issue.repository.name,
@@ -59,6 +69,6 @@ def create_date_for_spreadsheet(issues, users):
                     'Closed' if issue.state == 'closed' else 'Working',
                     '' if len(size_label) == 0 else size_label[0],
                     issue.html_url,
-                    issue.updated_at
+                    issue.updated_at if issue.state != 'closed' else issue.closed_at
                 ])
     return worksheet_data

--- a/lib/xlsx.py
+++ b/lib/xlsx.py
@@ -46,19 +46,19 @@ def write_gh_data_to_worksheet(worksheet, worksheet_data, workbook_formats):
     row = 2
     col = 0
 
-    for name, repo, issue, status, size, url, updated_at in worksheet_data:
+    for name, repo, issue, status, size, url, updated_or_closed_at in worksheet_data:
         bg_yellow = workbook_formats['bg_yellow']
         time_diff_hours = None
+        print(status)
         if size:
-            time_diff_hours = businesshrs.difference(updated_at, today).timedelta.total_seconds() / 3600
-
-        if time_diff_hours and time_diff_hours > 0:
+            time_diff_hours = businesshrs.difference(updated_or_closed_at, today).timedelta.total_seconds() / 3600
+        if (time_diff_hours and time_diff_hours > 0) and status != 'Closed':
             worksheet.write_string(row, col, name, cell_format=bg_yellow)
             worksheet.write_string(row, col + 1, repo, cell_format=bg_yellow)
             worksheet.write_url(row, col + 2, url, string=issue, cell_format=bg_yellow)
             worksheet.write_string(row, col + 3, status, cell_format=bg_yellow)
             worksheet.write_string(row, col + 4, size, cell_format=bg_yellow)
-            worksheet.write_datetime(row, col + 5, updated_at, workbook_formats['date_format_yellow'])
+            worksheet.write_datetime(row, col + 5, updated_or_closed_at, workbook_formats['date_format_yellow'])
             row += 1
             continue
 
@@ -67,5 +67,5 @@ def write_gh_data_to_worksheet(worksheet, worksheet_data, workbook_formats):
         worksheet.write_url(row, col + 2, url, string=issue)
         worksheet.write_string(row, col + 3, status)
         worksheet.write_string(row, col + 4, size)
-        worksheet.write_datetime(row, col + 5, updated_at, workbook_formats['date_format'])
+        worksheet.write_datetime(row, col + 5, updated_or_closed_at, workbook_formats['date_format'])
         row += 1


### PR DESCRIPTION
We were getting issues closed long time ago because I was using the `updated_at` date. 

Instead I am now doing a calculation to see if the Closed issue was actually closed before the `start_date` in which case it doesn't get added into the `worksheet_data`.